### PR TITLE
fix SmartAudio v2.1 pitmode enable

### DIFF
--- a/src/src/main.c
+++ b/src/src/main.c
@@ -23,9 +23,6 @@ static void start_serial(uint8_t type)
 
 void setup(void)
 {
-  // Force pitmode enabled after boot
-  pitMode = 1;
-
   spiPinSetup();
   target_rfPowerAmpPinSetup();
 
@@ -43,10 +40,10 @@ void setup(void)
 
   // TODO DEBUG! Below flashing is just for testing. Delete later.
 #if DEBUG
-  setPowermW(0); // 0mV
-  //setPowermW(25); // 1170mV
-  //setPowermW(100); // 1225mV
-  //setPowermW(400);
+  // target_set_power_mW(0); // 0mV
+  // target_set_power_mW(25); // 1170mV
+  // target_set_power_mW(100); // 1225mV
+  // target_set_power_mW(400);
 #endif /* DEBUG */
 }
 

--- a/src/src/rtc6705.c
+++ b/src/src/rtc6705.c
@@ -71,10 +71,6 @@ void rtc6705PowerAmpOff(void)
 
 void rtc6705WriteFrequency(uint32_t newFreq)
 {
-  /* Update only if freq is changed */
-  if (myEEPROM.currFreq == newFreq)
-    return;
-
   uint32_t freq = newFreq * 1000U;
   freq /= 40;
   uint32_t SYN_RF_N_REG = freq / 64;

--- a/src/src/rtc6705.c
+++ b/src/src/rtc6705.c
@@ -71,12 +71,19 @@ void rtc6705PowerAmpOff(void)
 
 void rtc6705WriteFrequency(uint32_t newFreq)
 {
+  /* Update only if freq is changed */
+  if (myEEPROM.currFreq == newFreq)
+    return;
+
   uint32_t freq = newFreq * 1000U;
   freq /= 40;
   uint32_t SYN_RF_N_REG = freq / 64;
   uint32_t SYN_RF_A_REG = freq % 64;
 
   uint32_t data = SynthesizerRegisterB | (1 << 4) | (SYN_RF_A_REG << 5) | (SYN_RF_N_REG << 12);
+
+  myEEPROM.currFreq = newFreq;
+  updateEEPROM = 1;
 
   /* Switch off */
   amp_state = 1; // Force off cmd rewrite

--- a/src/src/smartAudio.c
+++ b/src/src/smartAudio.c
@@ -17,6 +17,8 @@ const uint16_t channelFreqTable[48] = {
 };
 
 
+
+/**** SmartAudio definitions ****/
 #define CRC_LEN         1
 #define LEGHT_CALC(len) (sizeof(sa_header_t) + CRC_LEN + (len))
 
@@ -32,8 +34,8 @@ enum {
     SA_CMD_GET_SETTINGS_V21 = 0x11,
 };
 
-#define PIT_MODE_FREQ_REQUEST   (0x1 << 14)
-#define PIT_MODE_FREQ_SET       (0x1 << 15)
+#define PIT_MODE_FREQ_GET   (0x1 << 14)
+#define PIT_MODE_FREQ_SET   (0x1 << 15)
 
 #define SA_SYNC_BYTE    0xAA
 #define SA_HEADER_BYTE  0x55
@@ -144,7 +146,7 @@ void smartaudioProcessFrequencyPacket(void)
     freq <<= 8;
     freq |= rxPacket[5];
 
-    if (freq & PIT_MODE_FREQ_REQUEST)
+    if (freq & PIT_MODE_FREQ_GET)
     {
         // POR is not supported in SA2.1 so return currFreq
         freq = myEEPROM.currFreq;
@@ -156,16 +158,12 @@ void smartaudioProcessFrequencyPacket(void)
     }
     else
     {
-        myEEPROM.currFreq = freq;
         rtc6705WriteFrequency(freq);
     }
 
     payload->data_u16[0] = (uint8_t)(freq >> 8);
     payload->data_u16[1] = (uint8_t)(freq);
     payload->reserved = RESERVE_BYTE;
-
-    myEEPROM.freqMode = 1;
-    updateEEPROM = 1;
 
     smartaudioSendPacket();
 }
@@ -179,10 +177,7 @@ void smartaudioProcessChannelPacket(void)
 
     if (channel < ARRAY_SIZE(channelFreqTable)) {
         myEEPROM.channel = channel;
-        myEEPROM.currFreq = channelFreqTable[channel];
-        rtc6705WriteFrequency(myEEPROM.currFreq);
-        myEEPROM.freqMode = 0;
-        updateEEPROM = 1;
+        rtc6705WriteFrequency(channelFreqTable[channel]);
     } else {
         channel = myEEPROM.channel;
     }

--- a/src/src/smartAudio.c
+++ b/src/src/smartAudio.c
@@ -203,9 +203,21 @@ void smartaudioProcessPowerPacket(void)
     if (data & 0x80) {
         /* SA2.1 sets the MSB to indicate power is in dB.
          * Set MSB to zero and currPower will now be in dB. */
-        setPowerdB(data & 0x7F);
+        data &= 0x7F;
+        if (!data) {
+            /* 0Db is pit mode enable */
+            pitMode = 1;
+            data = myEEPROM.currPowerdB;
+        }
+        setPowerdB(data);
     } else {
-        setPowermW(data);
+        if (!data) {
+            /* 0Db is pit mode enable */
+            pitMode = 1;
+            setPowerdB(myEEPROM.currPowerdB);
+        } else {
+            setPowermW(data);
+        }
     }
 
     payload->data_u8 = myEEPROM.currPowerdB;

--- a/src/src/smartAudio.c
+++ b/src/src/smartAudio.c
@@ -237,10 +237,13 @@ void smartaudioProcessModePacket(void)
     myEEPROM.pitmodeInRange = bitRead(data, 0);
     myEEPROM.pitmodeOutRange = bitRead(data, 1);
 
-    // This bit is only for CLEARING pitmode.  It does not turn pitMode on and off!!!
-    if (bitRead(data, 2))
-    {
+    // This bit is only for CLEARING pitmode.
+    if (bitRead(data, 2)) {
         pitMode = 0;
+        setPowerdB(myEEPROM.currPowerdB);
+    } else if (bitRead(data, 0) || bitRead(data, 1)) {
+        /* Enable pitmode if PIR or POR is set */
+        pitMode = 1;
         setPowerdB(myEEPROM.currPowerdB);
     }
 

--- a/src/src/tramp.c
+++ b/src/src/tramp.c
@@ -74,10 +74,10 @@ void trampBuildsPacket(void)
 
 void trampProcessFPacket(void)
 {
-    myEEPROM.currFreq = rxPacket[2] | (rxPacket[3] << 8);
-    rtc6705WriteFrequency(myEEPROM.currFreq);
-
-    updateEEPROM = 1;
+    uint32_t freq = rxPacket[3];
+    freq <<= 8;
+    freq |= rxPacket[2];
+    rtc6705WriteFrequency(freq);
 }
 
 void trampProcessPPacket(void)


### PR DESCRIPTION
SA v2.1 uses POWER_SET 0dB command to enable pitmode. 

```
    if (saDevice.version >= 3 && !saDevice.willBootIntoPitMode) {
        if (onoff) {
            // enable pitmode using SET_POWER command with 0 dbm.
            // This enables pitmode without causing the device to boot into pitmode next power-up
            static uint8_t buf[6] = { 0xAA, 0x55, SACMD(SA_CMD_SET_POWER), 1 };
            buf[4] = 0 | 128;
            buf[5] = CRC8(buf, 5);
            saQueueCmd(buf, 6);
```
