### PR TITLE
Simulated EEPROM for gd32

### DIFF
--- a/src/src/common.c
+++ b/src/src/common.c
@@ -89,15 +89,14 @@ void setPowerdB(float dB)
     updateEEPROM = 1;
 
     if (pitMode)
-        // Pit mode set => force output power to zero
-        dB = 0;
-
-    if (dB <= 1)
-        rtc6705PowerAmpOff();
-    else
-        rtc6705PowerAmpOn();
-
-    target_set_power_dB(dB);
+    {
+      rtc6705PowerAmpOff();
+      target_set_power_dB(0);
+    } else
+    {
+      rtc6705PowerAmpOn();
+      target_set_power_dB(dB);
+    }
 }
 
 void setPowermW(uint16_t mW)

--- a/src/src/gd32f1x0/EEPROM.c
+++ b/src/src/gd32f1x0/EEPROM.c
@@ -1,11 +1,86 @@
 #include "EEPROM.h"
+#include <gd32f1x0.h>
+
+#ifndef FLASH_BASE
+#define FLASH_BASE  0x08000000U
+#endif
+#define FLASH_SIZE  0x8000U     // 32kB
+#define FLASH_END   (FLASH_BASE + FLASH_SIZE)
+#define PAGE_SIZE   0x400U
+
+#define EEPROM_SIZE (PAGE_SIZE)
+#define EEPROM_ADDR (FLASH_END - EEPROM_SIZE)
+
+
+static int flash_storage_erase(uint32_t address)
+{
+    /* unlock the flash program/erase controller */
+    //fmc_unlock();
+
+    /* clear all pending flags */
+    fmc_flag_clear(FMC_FLAG_END | FMC_FLAG_WPERR | FMC_FLAG_PGERR);
+
+    /* erase the flash pages */
+    for (; address < FLASH_END; address += PAGE_SIZE) {
+        if (fmc_page_erase(address) != FMC_READY) {
+            break;
+        }
+        fmc_flag_clear(FMC_FLAG_END | FMC_FLAG_WPERR | FMC_FLAG_PGERR);
+    }
+
+    /* lock the main FMC after the erase operation */
+    //fmc_lock();
+
+    return (address >= FLASH_END) ? 0 : -1;
+}
+
+
+static int flash_storage_write(uint32_t const * data, uint32_t size)
+{
+    if (EEPROM_SIZE < size)
+        return -1;
+
+    /* unlock the flash program/erase controller */
+    fmc_unlock();
+
+    uint32_t address = EEPROM_ADDR;
+
+    if (flash_storage_erase(address) < 0) {
+        // Erase failed
+        fmc_lock();
+        return -1;
+    }
+
+    /* program flash */
+    while (size-- && address < FLASH_END) {
+        if (fmc_word_program(address, *data++) != FMC_READY) {
+            break;
+        }
+        address += 4U;
+        fmc_flag_clear(FMC_FLAG_END | FMC_FLAG_WPERR | FMC_FLAG_PGERR);
+    }
+
+    /* lock the main FMC after the program operation */
+    fmc_lock();
+
+    if (size || address < FLASH_END)
+        return -1;
+    return 0;
+}
+
 
 void eeprom_update_block(uint16_t idx, uint8_t *ptr, uint32_t len)
 {
-
+    (void)idx;
+    flash_storage_write((uint32_t*)ptr, ((len + 3) / 4));
 }
 
 void eeprom_read_block(const uint16_t idx, uint8_t *ptr, uint32_t len)
 {
+    (void)idx;
+    __IO uint8_t *read_ptr = (uint8_t*)EEPROM_ADDR;
 
+    while (len--) {
+        *ptr++ = *read_ptr++;
+    }
 }

--- a/src/src/main.c
+++ b/src/src/main.c
@@ -26,6 +26,8 @@ void setup(void)
 
   readEEPROM();
 
+  pitMode = myEEPROM.pitmodeInRange;
+
   start_serial(myEEPROM.vtxMode);
 
   rtc6705ResetState(); // During testing registers got messed up. So now it gets reset on boot!

--- a/src/src/openVTxEEPROM.c
+++ b/src/src/openVTxEEPROM.c
@@ -1,9 +1,12 @@
 #include "openVTxEEPROM.h"
+#include "targets.h"
 #include <EEPROM.h>
 
-uint8_t updateEEPROM;
 
 openVTxEEPROM myEEPROM;
+uint32_t eeprom_last_write;
+uint8_t updateEEPROM;
+
 
 void defaultEEPROM(void)
 {
@@ -18,7 +21,7 @@ void defaultEEPROM(void)
     myEEPROM.currPowermW = 0; // Required due to rounding errors when converting between dBm and mW
     myEEPROM.unlocked = 1;
 
-    EEPROM_put(0, myEEPROM);
+    updateEEPROM = 1;
 }
 
 void readEEPROM(void)
@@ -28,12 +31,15 @@ void readEEPROM(void)
     if (myEEPROM.version != versionEEPROM) {
         defaultEEPROM();
     }
+    eeprom_last_write = millis();
 }
 
 void writeEEPROM(void)
 {
-    if (updateEEPROM) {
+    uint32_t const now = millis();
+    if (updateEEPROM && 1000 <= (now - eeprom_last_write)) {
         EEPROM_put(0, myEEPROM);
         updateEEPROM = 0;
+        eeprom_last_write = now;
     }
 }

--- a/src/src/openVTxEEPROM.h
+++ b/src/src/openVTxEEPROM.h
@@ -2,7 +2,7 @@
 
 #include <stdint.h>
 
-#define versionEEPROM 0x100
+#define versionEEPROM 0x101
 
 extern uint8_t updateEEPROM;
 

--- a/src/src/openVTxEEPROM.h
+++ b/src/src/openVTxEEPROM.h
@@ -2,7 +2,7 @@
 
 #include <stdint.h>
 
-#define versionEEPROM 0x101
+#define versionEEPROM 0x110
 
 extern uint8_t updateEEPROM;
 
@@ -22,7 +22,7 @@ typedef struct
     uint8_t pitmodeInRange;
     uint8_t pitmodeOutRange;
     float currPowerdB;
-    uint8_t currPowermW; // Required due to rounding errors when converting between dBm and mW
+    uint16_t currPowermW; // Required due to rounding errors when converting between dBm and mW
     uint8_t unlocked;
 } openVTxEEPROM;
 

--- a/src/src/rtc6705.c
+++ b/src/src/rtc6705.c
@@ -90,6 +90,5 @@ void rtc6705WriteFrequency(uint32_t newFreq)
   sendBits(data);
 
   /* Restore state */
-  rtc6705PowerAmpOn();
   setPowerdB(myEEPROM.currPowerdB);
 }


### PR DESCRIPTION
End of the flash (last flash page) is used to simulate EEPROM.
Stores and reads values correctly now.